### PR TITLE
Update source files to handle deprecated function (nanmean)

### DIFF
--- a/src/dataset_gbtfil.py
+++ b/src/dataset_gbtfil.py
@@ -19,7 +19,8 @@
 import os, fnmatch, sys, pickle
 import numpy as np
 import pylab
-from scipy.stats import nanmean
+from numpy import nanmean
+#from scipy.stats import nanmean
 from dataset import Dataset
 import matplotlib
 import datetime

--- a/src/demud.py
+++ b/src/demud.py
@@ -20,7 +20,8 @@
 import sys, os
 import numpy as np
 from numpy import linalg
-from scipy.stats import nanmean
+from numpy import nanmean
+#from scipy.stats import nanmean
 import math
 import copy, base64, time
 import csv


### PR DESCRIPTION
There was an error running 'python src/demud.py'. nanmean was a deprecated function that was removed from scipy.stats in version 0.18.0. I've replaced the source files to import from numpy instead, where the nanmean function is present.