### PR TITLE
Resolve dependency errors and remove residual normalization

### DIFF
--- a/demud/dataset_envi.py
+++ b/demud/dataset_envi.py
@@ -25,7 +25,7 @@ import h5py
 from matplotlib.patches import Rectangle
 from dataset import *
 from dataset_libs import LIBSData
-from nims_data import NimsQube
+#from nims_data import NimsQube
 from log import printt
 
 ################### ENVI ##############

--- a/demud/dataset_float_classes.py
+++ b/demud/dataset_float_classes.py
@@ -148,18 +148,8 @@ class CNNFeat(FloatDataset):
     # Had ndarrays converting to lists before, not necessary
     inecho = x
     recon = r
-    # Residual calculation - element-wise subtraction. Values are clipped to a
-    # minimum of zero, as there are no negative values in the input vector.
-    resid = (x - r)#.clip(min=0)
-
-    # turns out, we need to maintain the euclidean norm for subtraction.
-    # we'll leave the reconstruction alone for now.
-    # also, clipping to a 0 minimum is a bad idea.
-
-    inecho_l2_norm = np.linalg.norm(inecho, 2)
-    resid_l2_norm = np.linalg.norm(resid, 2)
-    normalized_resid = (resid / resid_l2_norm) * inecho_l2_norm
-
+    # Residual calculation - element-wise subtraction.
+    resid = (x - r)
 
     # Write original, reconstructed, and residual vectors of selections 
     # into a csv
@@ -173,7 +163,7 @@ class CNNFeat(FloatDataset):
 
     with open(residfile, 'a') as f:
       csvwriter = csv.writer(f, dialect='excel')
-      csvwriter.writerow(normalized_resid)
+      csvwriter.writerow(resid)
 
 ###############################################################################
 #

--- a/demud/demud.py
+++ b/demud/demud.py
@@ -618,6 +618,7 @@ def  demud(ds, k, nsel, scoremethod='lowhigh', svdmethod='full',
   - 'full': Recompute SVD from scratch.
   - 'increm-ross': Ross et al.'s method for incremental update,
     with mean tracking.
+  - 'increm-brand': Brand's incremental SVD method
 
   'missingmethod' indicates how to handle missing (NaN) values:
   - 'zero': set missing values to zero
@@ -1252,7 +1253,7 @@ def  svd_print():
   printt("- 'increm-brand': Brand's method for incremental update,")
   printt("         with mean tracking. Can handle missing values.")
   printt("")
-  printt("--increm is a shortcut for --svdmethod=increm-ross.")
+  printt("--increm is a shortcut for --svdmethod=increm-brand.")
   printt("")
   exit()
 
@@ -1517,7 +1518,7 @@ def  parse_args():
 
   params.add_option('--svdmethod', help="SVD method to use on each iteration (see --svdmethods for a list)",
                       default='default', type=str, action='store', dest='svdmethod')
-  params.add_option('--increm', help="Same as --svdmethod=increm-ross",
+  params.add_option('--increm', help="Same as --svdmethod=increm-brand",
                       default=False, action='store_true', dest='increm')
   params.add_option('--missingdatamethod', help="How to handle missing data (see --missingdatamethods for a list)",
                       default='none', type=str, action='store', dest='missingdatamethod')    
@@ -1661,7 +1662,7 @@ def  check_opts(datatypes):
       exit()
           
   # Check to make sure that --svdmethod has an appropriate argument
-  if log.opts['svdmethod'] != 'increm-ross' and log.opts['svdmethod'] != 'default' and log.opts['increm']:
+  if log.opts['svdmethod'] != 'increm-brand' and log.opts['svdmethod'] != 'default' and log.opts['increm']:
     printt("Error: cannot specify --increm along with different svdmethod.")
     printt("Use --svdmethods for more info.")
     exit()
@@ -1669,7 +1670,7 @@ def  check_opts(datatypes):
   if log.opts['svdmethod'] == 'default': log.opts['svdmethod'] = 'full'    
   
   if log.opts['increm']: 
-    log.opts['svdmethod'] = 'increm-ross'
+    log.opts['svdmethod'] = 'increm-brand'
     printt("Using increm")
     
   svdmethods = ('full', 'increm-ross', 'increm-brand')

--- a/demud/demud.py
+++ b/demud/demud.py
@@ -35,8 +35,8 @@ from dataset_des import DESData
 #from dataset_misr import MISRDataTime
 #from dataset_libs import LIBSData
 #from dataset_finesse import FINESSEData
-from dataset_envi import ENVIData
-from dataset_envi import SegENVIData
+#from dataset_envi import ENVIData
+#from dataset_envi import SegENVIData
 #from dataset_irs  import IRSData
 #from dataset_kepler import KeplerData
 #from dataset_mastcam import MastcamData
@@ -720,10 +720,13 @@ def  demud(ds, k, nsel, scoremethod='lowhigh', svdmethod='full',
   log.logfilename = os.path.join(outdir, 'demud.log')
   log.logfile     = open(log.logfilename, 'w')
   # Save RGB visualization, if appropriate
-  if (isinstance(ds, SegENVIData) or
-      isinstance(ds, ENVIData)):
-    ds.write_RGB(os.path.join(outdir,
-                              '%s-rgb-viz.png' % ds.name.split('-')[1]))
+  try:
+    if (isinstance(ds, SegENVIData) or
+        isinstance(ds, ENVIData)):
+      ds.write_RGB(os.path.join(outdir,
+                                '%s-rgb-viz.png' % ds.name.split('-')[1]))
+  except:
+    printt("SegENVIData and ENVIData not imported.")
 
   ###############################################
   # Print dataset info


### PR DESCRIPTION
Fixes #17 by wrapping ENVIData and SegENVIData instance checking in a try-except and commenting out the non-standard nims_data dependency.

Removed residual normalization for -v; not normalizing the residual for CNN features is the current method.