### PR TITLE
During first item SVD initialization, set U[0] to 1

### DIFF
--- a/demud/demud.py
+++ b/demud/demud.py
@@ -313,10 +313,12 @@ def  update_model(X, U, S, k, n, mu,
   # If there is no previous U, and we just got a single item in X,
   # set U to all 0's (degenerate SVD),
   # and return it with mu.
+  # (PR #22 sets first value to 1; see decals implementation)
   if U == [] and X.shape[1] == 1:
     mu   = X
     # Do this no matter what.  Let mu get NaNs in it as needed.
     U    = np.zeros_like(mu)
+    U[0] = 1
     S    = np.array([0])
     n    = 1
     pcts = [1.0]


### PR DESCRIPTION
Sets `U[0]=1` for first item SVD initialization for all data sets, following precedent of decals implementation.